### PR TITLE
Aceitando "P" e "0" como dígitos válidos.

### DIFF
--- a/lib/banking_data_validator/bank/bradesco.rb
+++ b/lib/banking_data_validator/bank/bradesco.rb
@@ -3,18 +3,23 @@ require "banking_data_validator/bank/base"
 module BankingDataValidator
   module Bank
     class Bradesco < Base
+
+      def initialize(branch, account_number, account_digit)
+        super
+        @account_digit = padding_with_zeros(account_digit.to_i)
+      end
+
       private
 
       def checksum
         case raw_checksum
-        when 0 then "0"
-        when 1 then "P"
-        else "#{11 - raw_checksum}"
+        when 1..9 then "#{raw_checksum}"
+        else "0"
         end
       end
 
       def raw_checksum
-        @raw_checksum ||= multiply_factors % 11
+        @raw_checksum ||= 11 - multiply_factors % 11
       end
 
       def factors

--- a/lib/banking_data_validator/version.rb
+++ b/lib/banking_data_validator/version.rb
@@ -1,3 +1,3 @@
 module BankingDataValidator
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/banking_data_validator/bank/bradesco_spec.rb
+++ b/spec/banking_data_validator/bank/bradesco_spec.rb
@@ -10,7 +10,9 @@ module BankingDataValidator
           expect(Bradesco.valid_account?(nil, "87087", "0")).to eq(true)
           expect(Bradesco.valid_account?(nil, "71000", "8")).to eq(true)
           expect(Bradesco.valid_account?(nil, "3257", "3")).to eq(true)
+          expect(Bradesco.valid_account?(nil, 121, "0")).to eq(true)
           expect(Bradesco.valid_account?(nil, 121, "p")).to eq(true)
+          expect(Bradesco.valid_account?(nil, "1818", "0")).to eq(true)
         end
 
         it "returns false when is given an account_number with an invalid digit" do


### PR DESCRIPTION
O Bradesco aceita dois dígitos diferentes como válidos para uma mesma conta ("0" ou "P").

Essa alteração faz com que qualquer dígito que não for um inteiro seja convertido para "0".